### PR TITLE
repos.conf: shallow clone/sync by default

### DIFF
--- a/repos.conf
+++ b/repos.conf
@@ -7,7 +7,8 @@
 [gentoo-mate]
 location = /var/db/repos/gentoo-mate
 sync-type = git
-clone-depth = 0
+clone-depth = 1
+sync-depth  = 1
 sync-uri =  https://github.com/oz123/mate-de-gentoo.git
 auto-sync = no
 masters = gentoo


### PR DESCRIPTION
Virtually all users don't care about the entire repo history. This sets
the default clone and sync to be shallow, i.e., only pulling the most
up-to-date changes. This reduces the load on the repo server and
consumed disk-space/inodes.

Advanced devleopers who require the repo history are unlikely to be
using the supplied `repos.conf`.