### PR TITLE
x11-libs/bamf: Fix invalid pathnames in the ebuild.

### DIFF
--- a/x11-libs/bamf/bamf-9999.ebuild
+++ b/x11-libs/bamf/bamf-9999.ebuild
@@ -51,7 +51,8 @@ DOCS=(AUTHORS COPYING COPYING.LGPL COPYING.LGPL-2.1 ChangeLog NEWS README TODO)
 src_prepare(){
 	sed -i 's/-Werror//' configure.ac
 	sed -i 's/tests//' Makefile.am
-	eapply "${FILESDIR}/${P}.patch"
+	eapply "${FILESDIR}/${PN}-0.5.0-disable-gtester2xunit-check.patch"
+	eapply "${FILESDIR}/${PN}-0.5.0-remove-desktop-fullname.patch"
 	eautoreconf
 	vala_src_prepare
 	default


### PR DESCRIPTION
The patch filename in the current ebuild is not correct and fails the emerge process.