### PR TITLE
app-editors/pluma: fix crash w/ FORTIFY_SOURCE=3

### DIFF
--- a/app-editors/pluma/files/pluma-1.26.0-fortify-source-3.patch
+++ b/app-editors/pluma/files/pluma-1.26.0-fortify-source-3.patch
@@ -1,0 +1,24 @@
+https://bugs.gentoo.org/903860
+https://github.com/mate-desktop/pluma/issues/664
+https://github.com/mate-desktop/pluma/pull/665
+https://github.com/mate-desktop/pluma/commit/8ca37beb259f7a62fef2005e888248ec880e44cd
+
+From 8ca37beb259f7a62fef2005e888248ec880e44cd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bal=C3=A1zs=20Dura-Kov=C3=A1cs?= <balping314@gmail.com>
+Date: Thu, 18 Aug 2022 17:44:41 +0200
+Subject: [PATCH] Fix out-of-bounds write
+
+Closes https://github.com/mate-desktop/pluma/issues/664
+
+The size of tempfont was one byte too short, so strcpy performed an out-of-bounds write of the terminating 0.
+--- a/pluma/pluma-window.c
++++ b/pluma/pluma-window.c
+@@ -318,7 +318,7 @@ pluma_window_key_press_event (GtkWidget   *widget,
+         g_strcanon (tempsize, "1234567890", '\0');
+         g_strreverse (tempsize);
+ 
+-        gchar tempfont [strlen (font)];
++        gchar tempfont [strlen (font) + 1];
+         strcpy (tempfont, font);
+         tempfont [strlen (font) - strlen (tempsize)] = 0;
+ 

--- a/app-editors/pluma/pluma-1.26.0-r3.ebuild
+++ b/app-editors/pluma/pluma-1.26.0-r3.ebuild
@@ -61,6 +61,10 @@ DEPEND="${COMMON_DEPEND}
 
 MATE_FORCE_AUTORECONF=true
 
+PATCHES=(
+	"${FILESDIR}"/${P}-fortify-source-3.patch
+)
+
 src_prepare() {
 	# Test require gvfs sftp fs mounted and schema's installed. Skip this one.
 	# https://github.com/mate-desktop/mate-text-editor/issues/33

--- a/app-editors/pluma/pluma-9999.ebuild
+++ b/app-editors/pluma/pluma-9999.ebuild
@@ -61,6 +61,10 @@ DEPEND="${COMMON_DEPEND}
 
 MATE_FORCE_AUTORECONF=true
 
+PATCHES=(
+	"${FILESDIR}"/pluma-1.26.0-fortify-source-3.patch
+)
+
 src_prepare() {
 	# Test require gvfs sftp fs mounted and schema's installed. Skip this one.
 	# https://github.com/mate-desktop/mate-text-editor/issues/33


### PR DESCRIPTION
Cherry-picked from 9ca63fb29f80c52ea7863d1b418e7c36abd6166f from Gentoo’s main Portage tree.

https://bugs.gentoo.org/903860
https://github.com/mate-desktop/pluma/issues/664